### PR TITLE
Fix friend request failures in Health Tracker

### DIFF
--- a/health/firestore.rules
+++ b/health/firestore.rules
@@ -1,0 +1,48 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // 使用者資料：本人可讀寫，其他登入者只能讀基本資料（好友碼查詢用）
+    match /users/{uid} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null && request.auth.uid == uid;
+
+      // 個人記錄（食物/水/運動/體重）：只有本人可讀寫
+      match /foodLogs/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
+      match /waterLogs/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
+      match /exerciseLogs/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
+      match /weightLogs/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
+
+      // 共享統計：本人可寫，好友可讀
+      match /sharedStats/{docId} {
+        allow write: if request.auth != null && request.auth.uid == uid;
+        allow read: if request.auth != null;
+      }
+    }
+
+    // 好友關係：雙方都可以讀，發起人可以建立，雙方可以更新/刪除
+    match /friendships/{fid} {
+      allow read: if request.auth != null &&
+        (resource.data.userA == request.auth.uid || resource.data.userB == request.auth.uid);
+
+      allow create: if request.auth != null &&
+        (request.resource.data.userA == request.auth.uid || request.resource.data.userB == request.auth.uid) &&
+        request.resource.data.initiatedBy == request.auth.uid &&
+        request.resource.data.status == 'pending';
+
+      allow update: if request.auth != null &&
+        (resource.data.userA == request.auth.uid || resource.data.userB == request.auth.uid);
+
+      allow delete: if request.auth != null &&
+        (resource.data.userA == request.auth.uid || resource.data.userB == request.auth.uid);
+    }
+  }
+}

--- a/health/js/db.js
+++ b/health/js/db.js
@@ -271,38 +271,27 @@ export async function getFriends(uid) {
 }
 
 export async function getPendingRequests(uid) {
-  const [qInA, qInB, qOutA, qOutB] = [
-    query(collection(db(), 'friendships'), where('userA', '==', uid), where('status', '==', 'pending'), where('initiatedBy', '!=', uid)),
-    query(collection(db(), 'friendships'), where('userB', '==', uid), where('status', '==', 'pending'), where('initiatedBy', '!=', uid)),
-    query(collection(db(), 'friendships'), where('initiatedBy', '==', uid), where('status', '==', 'pending')),
-    query(collection(db(), 'friendships'), where('initiatedBy', '==', uid), where('status', '==', 'pending'))
-  ];
+  const [snapA, snapB] = await Promise.all([
+    getDocs(query(collection(db(), 'friendships'), where('userA', '==', uid), where('status', '==', 'pending'))),
+    getDocs(query(collection(db(), 'friendships'), where('userB', '==', uid), where('status', '==', 'pending')))
+  ]);
 
   const incoming = [];
   const outgoing = [];
+  const seen = new Set();
 
-  // Incoming: userA or userB is me, but initiatedBy != me
-  const inSnaps = await Promise.all([getDocs(qInA), getDocs(qInB)]);
-  for (const snap of inSnaps) {
-    for (const d of snap.docs) {
-      if (d.data().initiatedBy !== uid) {
-        const friendUid = d.data().userA === uid ? d.data().userB : d.data().userA;
-        const profile = await getUserProfile(friendUid);
-        if (profile) incoming.push({ fid: d.id, ...profile });
-      }
-    }
-  }
-
-  // Outgoing: initiated by me, status pending
-  const outSnap = await getDocs(query(
-    collection(db(), 'friendships'),
-    where('initiatedBy', '==', uid),
-    where('status', '==', 'pending')
-  ));
-  for (const d of outSnap.docs) {
-    const friendUid = d.data().userA === uid ? d.data().userB : d.data().userA;
+  for (const d of [...snapA.docs, ...snapB.docs]) {
+    if (seen.has(d.id)) continue;
+    seen.add(d.id);
+    const data = d.data();
+    const friendUid = data.userA === uid ? data.userB : data.userA;
     const profile = await getUserProfile(friendUid);
-    if (profile) outgoing.push({ fid: d.id, ...profile });
+    if (!profile) continue;
+    if (data.initiatedBy === uid) {
+      outgoing.push({ fid: d.id, ...profile });
+    } else {
+      incoming.push({ fid: d.id, ...profile });
+    }
   }
 
   return { incoming, outgoing };

--- a/health/js/exercise.js
+++ b/health/js/exercise.js
@@ -131,6 +131,8 @@ async function deleteEntry(logId) {
     _logs = _logs.filter(l => l.id !== logId);
     renderList();
     showToast('已刪除');
+  } catch (e) {
+    showToast('刪除失敗，請再試一次', 'error');
   } finally {
     hideLoading();
   }

--- a/health/js/friends.js
+++ b/health/js/friends.js
@@ -82,14 +82,15 @@ async function addFriend() {
     await sendFriendRequest(_uid, targetUser.uid);
     input.value = '';
     showToast(`已送出好友邀請給 ${targetUser.displayName || '對方'}`);
-    await loadPendingRequests();
   } catch (e) {
     if (e.message === 'already_friends') showToast('你們已經是好友了', 'warning');
     else if (e.message === 'already_pending') showToast('已送出邀請，等待對方確認', 'warning');
     else showToast('送出邀請失敗，請再試一次', 'error');
+    return;
   } finally {
     hideLoading();
   }
+  await loadPendingRequests();
 }
 
 async function loadPendingRequests() {

--- a/health/js/water.js
+++ b/health/js/water.js
@@ -96,6 +96,8 @@ async function addWater(ml) {
     if (total >= goals.dailyWaterMl) showToast('達成今日喝水目標！💧', 'success');
     else showToast(`已記錄 ${ml} ml`);
     await renderWeekChart();
+  } catch (e) {
+    showToast('記錄失敗，請再試一次', 'error');
   } finally {
     hideLoading();
   }
@@ -111,6 +113,8 @@ async function deleteWaterEntry(logId) {
     renderRing();
     renderLogList();
     showToast('已刪除');
+  } catch (e) {
+    showToast('刪除失敗，請再試一次', 'error');
   } finally {
     hideLoading();
   }


### PR DESCRIPTION
## Summary

- 修正送出好友邀請後顯示「失敗」的問題
- 移除需要 Firestore 複合索引的查詢，改用純等式篩選

## 修改內容

- **friends.js**: 將 `loadPendingRequests()` 移到 `sendFriendRequest` 的 try-catch 外，避免索引錯誤被誤判為邀請失敗
- **db.js**: 重寫 `getPendingRequests()`，移除 `!=` 運算子，不再需要在 Firebase Console 建立複合索引
- **firestore.rules**: 新增 Firestore 安全規則（需手動貼到 Firebase Console）

https://claude.ai/code/session_01SBGXqBvu2hB32yKYmTVmxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBGXqBvu2hB32yKYmTVmxZ)_