### PR TITLE
Add category filter to food search

### DIFF
--- a/health/index.html
+++ b/health/index.html
@@ -515,6 +515,7 @@
             <!-- DB Search Tab -->
             <div class="tab-pane fade show active" id="tab-db">
               <input type="text" id="food-search" class="form-control mb-2" placeholder="搜尋食物名稱..." />
+              <div id="food-category-filter" class="d-flex gap-2 flex-nowrap mb-2" style="overflow-x:auto;padding-bottom:4px"></div>
               <div id="food-search-results" class="food-search-results"></div>
               <div id="food-selected-preview" class="d-none">
                 <div class="alert alert-success py-2 small" id="food-selected-name"></div>

--- a/health/js/food-database.js
+++ b/health/js/food-database.js
@@ -377,11 +377,12 @@ export const FOOD_DB = [
   { id: 'tw_190', name: '酪梨', category: '健身餐', calories: 160, protein: 2, carbs: 9, fat: 15, serving: '1/2顆(約100g)' }
 ];
 
-export function searchFoods(query) {
-  if (!query || query.trim() === '') return FOOD_DB.slice(0, 20);
+export function searchFoods(query, category = '') {
+  const pool = category ? FOOD_DB.filter(f => f.category === category) : FOOD_DB;
+  if (!query || query.trim() === '') return pool.slice(0, 30);
   const q = query.trim().toLowerCase();
-  const exact = FOOD_DB.filter(f => f.name.toLowerCase().startsWith(q));
-  const contains = FOOD_DB.filter(f => !f.name.toLowerCase().startsWith(q) && f.name.toLowerCase().includes(q));
-  const catMatch = FOOD_DB.filter(f => !f.name.toLowerCase().includes(q) && f.category.toLowerCase().includes(q));
-  return [...exact, ...contains, ...catMatch].slice(0, 20);
+  const exact = pool.filter(f => f.name.toLowerCase().startsWith(q));
+  const contains = pool.filter(f => !f.name.toLowerCase().startsWith(q) && f.name.toLowerCase().includes(q));
+  const catMatch = pool.filter(f => !f.name.toLowerCase().includes(q) && f.category.toLowerCase().includes(q));
+  return [...exact, ...contains, ...catMatch].slice(0, 30);
 }

--- a/health/js/food.js
+++ b/health/js/food.js
@@ -1,6 +1,6 @@
 import { addFoodLog, getFoodLogs, deleteFoodLog, saveCustomFood, getCustomFoods } from './db.js';
 import { showToast, showLoading, hideLoading, getGoals } from './app.js';
-import { searchFoods } from './food-database.js';
+import { searchFoods, FOOD_CATEGORIES } from './food-database.js';
 import { todayStr } from './db.js';
 
 const MEAL_LABELS = { breakfast: '早餐', lunch: '午餐', dinner: '晚餐', snack: '點心' };
@@ -14,6 +14,7 @@ let _selectedFood = null;
 let _foodModal = null;
 let _searchDebounce = null;
 let _customFoods = [];
+let _selectedCategory = '';
 
 export function initFood(uid) {
   _uid = uid;
@@ -35,6 +36,24 @@ export function initFood(uid) {
 
   // Reset modal state when closed
   document.getElementById('modal-add-food').addEventListener('hidden.bs.modal', resetModal);
+
+  // Category filter buttons
+  const filterContainer = document.getElementById('food-category-filter');
+  filterContainer.innerHTML = ['全部', '我的食物', ...FOOD_CATEGORIES].map(cat => `
+    <button class="btn btn-sm food-cat-btn ${cat === '' || cat === '全部' ? 'btn-primary' : 'btn-outline-secondary'} flex-shrink-0"
+      data-cat="${cat === '全部' ? '' : cat}"
+      style="white-space:nowrap;font-size:0.75rem">${cat}</button>
+  `).join('');
+  filterContainer.querySelectorAll('.food-cat-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      _selectedCategory = btn.dataset.cat;
+      filterContainer.querySelectorAll('.food-cat-btn').forEach(b => {
+        b.className = b.className.replace('btn-primary', 'btn-outline-secondary');
+      });
+      btn.className = btn.className.replace('btn-outline-secondary', 'btn-primary');
+      renderSearchResults(document.getElementById('food-search').value);
+    });
+  });
 
   loadDay();
   getCustomFoods(uid).then(foods => { _customFoods = foods; }).catch(() => {});
@@ -139,34 +158,40 @@ function openAddFoodModal(meal) {
 
 function renderSearchResults(query) {
   const q = (query || '').trim().toLowerCase();
-  const dbResults = searchFoods(query);
 
-  const matchedCustom = q
-    ? _customFoods.filter(f => f.name.toLowerCase().includes(q))
-    : _customFoods.slice(0, 5);
+  // 「我的食物」分類
+  if (_selectedCategory === '我的食物') {
+    const filtered = q ? _customFoods.filter(f => f.name.toLowerCase().includes(q)) : _customFoods;
+    renderList(filtered, '尚無自訂食物記錄');
+    return;
+  }
 
-  // Custom foods first, then db foods (deduplicate by name)
+  const dbResults = searchFoods(query, _selectedCategory);
+  const matchedCustom = _selectedCategory
+    ? []
+    : (q ? _customFoods.filter(f => f.name.toLowerCase().includes(q)) : _customFoods.slice(0, 5));
+
   const customNames = new Set(matchedCustom.map(f => f.name));
   const combined = [
     ...matchedCustom,
     ...dbResults.filter(f => !customNames.has(f.name))
-  ].slice(0, 20);
+  ].slice(0, 30);
 
+  const showRecentHeader = !q && !_selectedCategory && _customFoods.length > 0;
+  renderList(combined, '找不到相符食物', showRecentHeader);
+}
+
+function renderList(items, emptyMsg, showRecentHeader = false) {
   const container = document.getElementById('food-search-results');
-  if (combined.length === 0) {
-    container.innerHTML = '<p class="text-muted small text-center py-2">找不到相符食物</p>';
+  if (items.length === 0) {
+    container.innerHTML = `<p class="text-muted small text-center py-2">${emptyMsg}</p>`;
     return;
   }
-
-  if (!q && _customFoods.length > 0) {
-    container.innerHTML = '<p class="text-muted small mb-1" style="font-size:0.7rem">⭐ 最近使用</p>' +
-      combined.map(f => foodResultHTML(f)).join('');
-  } else {
-    container.innerHTML = combined.map(f => foodResultHTML(f)).join('');
-  }
+  const header = showRecentHeader ? '<p class="text-muted small mb-1" style="font-size:0.7rem">⭐ 最近使用</p>' : '';
+  container.innerHTML = header + items.map(f => foodResultHTML(f)).join('');
 
   window._selectFood = (id) => {
-    const food = combined.find(f => f.id === id);
+    const food = items.find(f => f.id === id);
     if (!food) return;
     _selectedFood = food;
     document.getElementById('food-selected-name').textContent =
@@ -259,7 +284,13 @@ async function deleteEntry(logId, mealType) {
 
 function resetModal() {
   _selectedFood = null;
+  _selectedCategory = '';
   document.getElementById('food-selected-preview').classList.add('d-none');
+  // Reset category buttons
+  document.querySelectorAll('.food-cat-btn').forEach((b, i) => {
+    b.className = b.className.replace('btn-primary', 'btn-outline-secondary');
+    if (i === 0) b.className = b.className.replace('btn-outline-secondary', 'btn-primary');
+  });
 }
 
 function escHtml(str) {


### PR DESCRIPTION
在食物新增 modal 的搜尋框下方加入橫向滑動的分類按鈕列。

- 全部 / 我的食物 / 便當 / 麵食 / 飲料 / 咖啡 / 麥當勞 / 肯德基 / 八方雲集 / 7-ELEVEN / 全家 / 健身餐 等
- 點選分類只顯示該類食物
- 搜尋框與分類可同時使用（先選分類再搜尋）
- 「我的食物」分類顯示手動輸入過的歷史

https://claude.ai/code/session_01SBGXqBvu2hB32yKYmTVmxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBGXqBvu2hB32yKYmTVmxZ)_